### PR TITLE
Add patch test and functionality for changing the name of a project

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,7 @@ app.post('/api/v1/projects', (request, response) => {
     })
     .catch(error => {
       return response.status(500).json({error})
-    });
+  });
 
     app.delete('/api/v1/projects', (request, response) => {
       database('projects').where('id', request.params.id).del()
@@ -84,6 +84,20 @@ app.post('/api/v1/projects', (request, response) => {
           response.status(500).json({ error });
         });
     });
+});
+
+app.patch('/api/v1/projects/:id', async (request, response) => {
+  const newProjectName = request.body;
+  const project = await database('projects').where('id', request.params.id).select();
+
+  if (project.length) {
+    await database('projects')
+      .where('id', request.params.id)
+      .update(newProjectName)
+    return response.status(202).json({ id: request.params.id })
+  } else {
+    return response.status(400).json({ error: `Could not find project with id of ${request.params.id}` })
+  }
 });
 
 app.post('/api/v1/palettes', (request, response) => {

--- a/app.test.js
+++ b/app.test.js
@@ -149,10 +149,8 @@ describe("Server", () => {
           const projectId = await database('projects').first('id').then(project => project.id); 
           console.log('projectid', projectId)
           const response = await request(app).delete(`/api/v1/projects/${projectId}`);
-          // console.log('db', database('projects'))
 
           expect(response.status).toBe(200);
-          // expect(response.body.error).toEqual('Project not found')
         })
 
         it('should return a 404 if the project is not found', async () => {
@@ -162,20 +160,37 @@ describe("Server", () => {
         })
       });
 
-      describe('PATCH /api/v1/palettes/:id', () => {
-        it('should return a 204 status code and updated the palettes name', async () => {
+    describe('PATCH /api/v1/projects/:id', () => {
+      it('should return a 204 status code and updated the projects name', async () => {
+        const updatedName = {
+          name: 'Fall'
+        }
+
+        const selectedPalette = await database('projects').first();
+        const id = selectedPalette.id;
+
+        const response = await request(app).patch(`/api/v1/projects/${id}`).send(updatedName);
+        const mockPalette = await database('projects').where('id', id);
+
+        expect(response.status).toBe(202);
+        expect(mockPalette[0].name).toEqual(updatedName.name)
+      });
+    });
+
+      describe('PATCH /api/v1/projects/:id', () => {
+        it('should return a 204 status code and updated the projects name', async () => {
           const updatedName = {
             name: 'Fall'
           }
     
-          const selectedPalette = await database('palettes').first();
-          const id = selectedPalette.id;
+          const selectedProject = await database('projects').first();
+          const id = selectedProject.id;
     
-          const response = await request(app).patch(`/api/v1/palettes/${id}`).send(updatedName);
-          const mockPalette = await database('palettes').where('id', id);
+          const response = await request(app).patch(`/api/v1/projects/${id}`).send(updatedName);
+          const mockProject = await database('projects').where('id', id);
     
           expect(response.status).toBe(202);
-          expect(mockPalette[0].name).toEqual(updatedName.name)
+          expect(mockProject[0].name).toEqual(updatedName.name)
         });
       });
 


### PR DESCRIPTION
What is this change? Adds test for happy path of project path and functionality
What does it fix? Patch allows for a project name change.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? Feature/ no, but the sad path was breaking it so we will circle back around to the sad path later.
How has it been tested? Yes it has been tested in Postman