### PR TITLE
Fix the endpoint to get palettes for a specific project

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,17 +51,17 @@ app.get("/api/v1/palettes", (request, response) => {
     });
 });
 
-app.get("/api/v1/palettes/:id", (request, response) => {
+app.get("/api/v1/projects/:id/palettes", (request, response) => {
   database("palettes")
-    .where("id", request.params.id)
+    .where("projectId", request.params.id)
     .select()
-    .then(project => {
-      if (project.length) {
-        return response.status(200).json(project);
-      } else {
+    .then(palettes => {
+      if (!palettes.length) {
         return response.status(404).json({
           error: "No palette found."
         });
+      } else {
+        return response.status(200).json(palettes);
       }
     })
     .catch(error => {

--- a/app.test.js
+++ b/app.test.js
@@ -50,16 +50,20 @@ describe("Server", () => {
     });
   });
 
-  describe("GET /api/v1/palettes/:id", () => {
-    it("should return a 200 status and a single palette if the palette exists", async () => {
-      const expectedPalette = await database("palettes").first();
-      const id = expectedPalette.id;
-      const response = await request(app).get(`/api/v1/palettes/${id}`);
-      const result = response.body[0];
+  describe("GET /api/v1/projects/:id/palettes", () => {
+    it('should return 200 status and all palettes for a project', async () => {
+      const expectedId = await database('projects').first('id').then(object => object.id)
+      const expectedPalettes = await database('palettes').where({ projectId: expectedId }).select()
+      const response = await request(app).get(`/api/v1/projects/${expectedId}/palettes`)
+      const palettes = response.body
 
-      expect(response.status).toBe(200);
-      expect(result[0]).toEqual(expectedPalette[0]);
-    });
+      expect(response.status).toBe(200)
+      expect(palettes[0].name).toEqual(expectedPalettes[0].name)
+  })
+  it('should return 404 status if passed a bad id param', async () => {
+      const response = await request(app).get('/api/v1/projects/2/palettes')
+      expect(response.status).toBe(404)
+  })
   });
 
   describe("GET /api/v1/search", () => {


### PR DESCRIPTION
What is this change? The endpoint url to get palettes for a specific project
What does it fix? we can now access the correct palettes
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? bug fix, not broken
How has it been tested? with the test suite