### PR TITLE
Request response

### DIFF
--- a/app.js
+++ b/app.js
@@ -182,7 +182,7 @@ app.delete("/api/v1/projects/:id", async (request, response) => {
       .where("id", request.params.id)
       .del();
 
-    response.status(200).json("This project has been deleted.");
+    response.status(200).json(`The project with the id ${request.params.id} has been deleted.`);
   } else {
     return response
       .status(400)

--- a/app.js
+++ b/app.js
@@ -87,7 +87,7 @@ app.get("/api/v1/search", (request, response) => {
     });
 });
 
-app.post("/api/v1/projects", (request, response) => {
+ app.post("/api/v1/projects", (request, response) => {
   const project = request.body;
 
   for (let requiredParameter of ["name"]) {

--- a/app.test.js
+++ b/app.test.js
@@ -180,7 +180,7 @@ describe("Server", () => {
       const response = await request(app).delete(`/api/v1/projects/${id}`);
 
       expect(response.status).toBe(200);
-      expect(response.body).toEqual("This project has been deleted.");
+      expect(response.body).toEqual(`The project with the id ${id} has been deleted.`);
     });
 
     it("should return a 400 and an error message", async () => {


### PR DESCRIPTION
What is this change? Adds specific id details in message on delete projects
What does it fix? Previously, response was returning "This project was deleted", now specifies id of the project.
Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version? Fix, no break
How has it been tested? yes in postman